### PR TITLE
feat: add SheetState in Bottom Sheet content callback

### DIFF
--- a/convention-plugins/src/main/kotlin/convention.publication.gradle.kts
+++ b/convention-plugins/src/main/kotlin/convention.publication.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.attafitamim.navigation"
-version = "3.0.2-alpha06"
+version = "3.0.2-alpha07"
 
 val javadocJar by tasks.registering(Jar::class) {
     archiveClassifier.set("javadoc")

--- a/router/compose/src/commonMain/kotlin/com/attafitamim/navigation/router/compose/screens/Destination.kt
+++ b/router/compose/src/commonMain/kotlin/com/attafitamim/navigation/router/compose/screens/Destination.kt
@@ -62,7 +62,7 @@ sealed interface Destination : PlatformScreen {
                         overrideScrimColor: Color? = null,
                         overrideDragHandle: @Composable (() -> Unit)? = null,
                         overrideWindowInsets: WindowInsets? = null,
-                        content: @Composable ColumnScope.() -> Unit
+                        content: @Composable ColumnScope.(SheetState) -> Unit
                     ) = object : BottomSheet {
 
                         @Composable
@@ -107,8 +107,9 @@ sealed interface Destination : PlatformScreen {
                                 scrimColor = scrimColor,
                                 dragHandle = dragHandle,
                                 windowInsets = windowInsets,
-                                content = content
-                            )
+                            ) {
+                                content(sheetState)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
In some cases we need to handle SheetState while using `BottomSheet` dialogs (for example, handling screen closing).
Also bumped version to 3.0.2-alpha07